### PR TITLE
BUG-6062: Instantiate new requests session on `APIRequest` initialization

### DIFF
--- a/mangopay/api.py
+++ b/mangopay/api.py
@@ -31,8 +31,8 @@ except ImportError:
 
 logger = logging.getLogger('mangopay')
 
-requests_session = requests.Session()
 rate_limits = None
+
 
 class APIRequest(object):
 
@@ -51,6 +51,7 @@ class APIRequest(object):
         self.auth_manager = AuthorizationTokenManager(self, storage_strategy)
         self.timeout = timeout
         self.proxies = proxies
+        self.requests_session = requests.Session()
 
     def set_rate_limit(self, rate_limit):
         global rate_limits
@@ -111,11 +112,11 @@ class APIRequest(object):
         request_started.send(url=url, data=truncated_data, headers=headers, method=method)
 
         try:
-            result = requests_session.request(method, url,
-                                              data=data,
-                                              headers=headers,
-                                              timeout=self.timeout,
-                                              proxies=self.proxies)
+            result = self.requests_session.request(method, url,
+                                                   data=data,
+                                                   headers=headers,
+                                                   timeout=self.timeout,
+                                                   proxies=self.proxies)
         except ConnectionError as e:
             msg = '{}'.format(e)
 


### PR DESCRIPTION
- Stop using global variable for `requests.Session()`, as this will be called only once during the entire app/pod lifespan.
- Move the session instantiation to the constructor of `APIRequest`, so we get fresh, still reusable sessions when needed.

:information_source: Further details about this PR can be read in my [BUG-2062 comment](https://plentific.atlassian.net/browse/BUG-2062?focusedCommentId=28491).